### PR TITLE
Handle differences in language codes

### DIFF
--- a/get_translations/po_export.go
+++ b/get_translations/po_export.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/text/language"
 )
 
 const (
@@ -51,26 +52,67 @@ func writeLocoPO(baseDir string, zipData io.ReadCloser) error {
 			continue
 		}
 
-		poFile, err := createOutputFile(baseDir, zipPath)
+		poDir, err := outputFromZip(baseDir, zipPath, zipFile)
 		if err != nil {
 			readErr = err
-			continue
 		}
-		if poFile == nil {
-			// this happens when we skip something - not an error, but e.g. a locale we don't want to process
+		if poDir == "" {
+			// skip
 			continue
 		}
 
-		_, err = writeZipFile(zipFile, poFile)
-		_ = poFile.Close()
-		if err != nil && err != io.EOF {
-			log.Errorf("error writing contents to po file: %v", err)
-			readErr = err
+		localeCode := localeFromPath(poDir)
+		l, err := language.Parse(localeCode)
+		if err != nil {
+			log.Errorf("language.Parse failed for %s: %v", localeCode, err)
 			continue
+		}
+		if l.String() != localeCode {
+			// go's language parsing ends up with a different code than we expect. copy the file out so that we have both.
+			log.Infof("mismatch for code %s: %s", localeCode, l.String())
+			newPath := strings.Replace(zipPath, fmt.Sprintf("/%s/", localeCode), fmt.Sprintf("/%s/", l.String()), 1)
+			poFile, _, err := createOutputFile(baseDir, newPath, true)
+			if err != nil {
+				log.Errorf("error creating dup output file for %s: %v", l.String(), err)
+				continue
+			}
+			_, err = writeZipFile(zipFile, poFile)
+			if err != nil && err != io.EOF {
+				log.Errorf("error writing dup output file for %s: %v", l.String(), err)
+			}
+			poFile.Close()
 		}
 	}
 
 	return readErr
+}
+
+func localeFromPath(dir string) string {
+	parts := strings.Split(dir, "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[len(parts)-2]
+}
+
+func outputFromZip(baseDir, zipPath string, zipFile *zip.File) (poDir string, err error) {
+	poFile, poDir, err := createOutputFile(baseDir, zipPath, false)
+	if err != nil {
+		return
+	}
+	if poFile == nil {
+		// this happens when we skip something - not an error, but e.g. a locale we don't want to process
+		return poDir, nil
+	}
+	defer poFile.Close()
+
+	_, err = writeZipFile(zipFile, poFile)
+	if err != nil && err != io.EOF {
+		log.Errorf("error writing contents to po file: %v", err)
+		return
+	}
+
+	return poDir, nil
 }
 
 // writeZipFile takes the compressed po file from the archive and writes it
@@ -84,7 +126,7 @@ func writeZipFile(zf *zip.File, out io.Writer) (int64, error) {
 	return io.CopyN(out, f, 10*1000000)
 }
 
-func createOutputFile(baseDir, zipPath string) (poFile *os.File, err error) {
+func createOutputFile(baseDir, zipPath string, noskip bool) (poFile *os.File, poDir string, err error) {
 	components := strings.Split(zipPath, "/")
 	if len(components) < 3 {
 		err = fmt.Errorf("path length for %s is not expected", zipPath)
@@ -94,10 +136,14 @@ func createOutputFile(baseDir, zipPath string) (poFile *os.File, err error) {
 	locale := strings.Replace(components[2], "_", "-", 1)
 	localeDir, ok := locales[locale]
 	if !ok {
-		log.Infof("skipping locale %s: not in locales map", locale)
-		return
+		if !noskip {
+			log.Infof("skipping locale %s: not in locales map", locale)
+			return
+		} else {
+			localeDir = locale
+		}
 	}
-	poDir := filepath.Join(baseDir, localeDir, "LC_MESSAGES")
+	poDir = filepath.Join(baseDir, localeDir, "LC_MESSAGES")
 	err = os.MkdirAll(poDir, os.ModePerm)
 	if err != nil {
 		err = fmt.Errorf("error creating output directory: %w", err)


### PR DESCRIPTION
`language.Parse("tl")` returns `fil` which causes us some problems at runtime. This checks for it and creates duplicate po files.