### PR TITLE
Use tag for backend to minimize size

### DIFF
--- a/get_translations/android.go
+++ b/get_translations/android.go
@@ -57,7 +57,7 @@ func updateAndroidAssets(apiKey, baseDir, tag string) error {
 	qp.Add("fallback", locoFallback)
 	qp.Add("index", "id")
 	if tag != "" {
-		qp.Add("filter", tag)
+		qp.Add(locoFilter, tag)
 	}
 	resp, err := locoRequest(apiKey, androidURL, qp)
 	if err != nil {

--- a/get_translations/assets.go
+++ b/get_translations/assets.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -51,7 +52,9 @@ func generateAssets(apiKey string, args []string) error {
 }
 
 func getAssets(apiKey string) (assets []LocoAsset, err error) {
-	resp, err := locoRequest(apiKey, locoAssetsURL, nil)
+	qp := url.Values{}
+	qp.Add(locoFilter, backendTag)
+	resp, err := locoRequest(apiKey, locoAssetsURL, qp)
 	if err != nil {
 		return
 	}

--- a/get_translations/po_export.go
+++ b/get_translations/po_export.go
@@ -16,13 +16,13 @@ import (
 
 const (
 	locoPOExportURL = locoBaseURL + "/export/archive/po.zip"
+	backendTag      = "backend"
 )
 
 func getPOExport(apiKey string, args []string) error {
 	qp := url.Values{}
 	qp.Add("index", "name")
-	// no filter, to avoid issues where a missing tag leads to a missing asset
-	// qp.Add("filter", "web-pub")
+	qp.Add(locoFilter, backendTag)
 	qp.Add("fallback", "en-US")
 
 	resp, err := locoRequest(apiKey, locoPOExportURL, qp)


### PR DESCRIPTION
Instead of pulling down all translations in the back end, just get the ones we need